### PR TITLE
Update to OpenAI 1.0 Migration standard.

### DIFF
--- a/llm_handler.py
+++ b/llm_handler.py
@@ -1,17 +1,17 @@
-import openai
+from openai import OpenAI
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage
 
 from params import OPENAI_MODEL, OPENAI_API_KEY, MISTRALAI_MODEL, MISTRALAI_API_KEY
 
-openai.api_key = OPENAI_API_KEY
+client = OpenAI(api_key = OPENAI_API_KEY)
 
 
 def send_to_chatgpt(msg_list):
-    completion = openai.ChatCompletion.create(
+    completion = client.chat.completions.create(
         model=OPENAI_MODEL, temperature=0.5, messages=msg_list
     )
-    chatgpt_response = completion.choices[0].message["content"]
+    chatgpt_response = completion.choices[0].message.content
     chatgpt_usage = completion.usage
     return chatgpt_response, chatgpt_usage
 


### PR DESCRIPTION
Details on migration can be found here. https://github.com/openai/openai-python/discussions/742

OpenAI moved to a client based for chat completion. Unless the user pins an old version it will not work on OpenAI out of the box.

Tested and jsonl output looks correct to me. 